### PR TITLE
[2022.10.17] Feat: 미리보기 컴포넌트

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 
 import GlobalStyle from "./GlobalStyle";
@@ -8,12 +8,14 @@ import Main from "../components/Main";
 import Preview from "../components/Preview";
 
 function App() {
+  const [buttonType, setButtonType] = useState();
+
   return (
     <AppContainer>
       <GlobalStyle />
       <Header />
-      <Preview />
-      <Footer />
+      <Main />
+      <Footer buttonType={buttonType} />
     </AppContainer>
   );
 }

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -5,13 +5,14 @@ import GlobalStyle from "./GlobalStyle";
 import Header from "../components/shared/layout/Header";
 import Footer from "../components/shared/layout/Footer";
 import Main from "../components/Main";
+import Preview from "../components/Preview";
 
 function App() {
   return (
     <AppContainer>
       <GlobalStyle />
       <Header />
-      <Main />
+      <Preview />
       <Footer />
     </AppContainer>
   );
@@ -20,6 +21,7 @@ function App() {
 const AppContainer = styled.div`
   display: flex;
   flex-direction: column;
+  align-items: center;
   width: 100vw;
   height: 100vh;
 `;

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -8,14 +8,14 @@ import Main from "../components/Main";
 import Preview from "../components/Preview";
 
 function App() {
-  const [buttonType, setButtonType] = useState();
+  const [pageType, setPageType] = useState("");
 
   return (
     <AppContainer>
       <GlobalStyle />
       <Header />
       <Main />
-      <Footer buttonType={buttonType} />
+      <Footer buttonType={pageType} />
     </AppContainer>
   );
 }

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -1,12 +1,8 @@
-import React, { useEffect } from "react";
+import React from "react";
 import styled from "styled-components";
 import SlideViewer from "./shared/SlideViewer/SlideViewer";
 
-function Preview({ onButtonType }) {
-  useEffect(() => {
-    onButtonType("preview");
-  }, [onButtonType]);
-
+function Preview() {
   return (
     <PreviewContainer>
       <SlideViewer />
@@ -18,7 +14,7 @@ const PreviewContainer = styled.div`
   display: flex;
   width: 100%;
   height: 100%;
-  padding: 0 10vh;
+  padding: 0 10vw;
   overflow: auto;
 `;
 

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -1,8 +1,12 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
 import SlideViewer from "./shared/SlideViewer/SlideViewer";
 
-function Preview() {
+function Preview({ onButtonType }) {
+  useEffect(() => {
+    onButtonType("preview");
+  }, [onButtonType]);
+
   return (
     <PreviewContainer>
       <SlideViewer />

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -1,0 +1,21 @@
+import React from "react";
+import styled from "styled-components";
+import SlideViewer from "./shared/SlideViewer/SlideViewer";
+
+function Preview() {
+  return (
+    <PreviewContainer>
+      <SlideViewer />
+    </PreviewContainer>
+  );
+}
+
+const PreviewContainer = styled.div`
+  display: flex;
+  width: 100%;
+  height: 100%;
+  padding: 0 10vh;
+  overflow: auto;
+`;
+
+export default Preview;

--- a/src/components/shared/SlideViewer/SlideList.js
+++ b/src/components/shared/SlideViewer/SlideList.js
@@ -6,11 +6,6 @@ function SlideList() {
   return (
     <SlideListContainer>
       <Slide />
-      <Slide />
-      <Slide />
-      <Slide />
-      <Slide />
-      <Slide />
     </SlideListContainer>
   );
 }

--- a/src/components/shared/SlideViewer/SlideViewer.js
+++ b/src/components/shared/SlideViewer/SlideViewer.js
@@ -1,6 +1,8 @@
 import React from "react";
 import styled from "styled-components";
+
 import SlideList from "./SlideList";
+import FileAttachment from "./FileAttachment";
 
 function SlideViewer() {
   return (

--- a/src/components/shared/layout/Footer.js
+++ b/src/components/shared/layout/Footer.js
@@ -7,6 +7,7 @@ function Footer() {
 
 const FooterContainer = styled.footer`
   height: 10%;
+  width: 100%;
   background-color: gray;
 `;
 

--- a/src/components/shared/layout/Footer.js
+++ b/src/components/shared/layout/Footer.js
@@ -1,10 +1,11 @@
 import React from "react";
 import styled from "styled-components";
+import PAGE_TYPES from "../../../config/constants/pageTypes";
 
 function Footer({ buttonType }) {
   return (
     <FooterContainer>
-      {buttonType === "preview" ? (
+      {buttonType === PAGE_TYPES.PREVIEW ? (
         <>
           <FooterButton>취소</FooterButton>
           <FooterButton>다운로드</FooterButton>
@@ -17,22 +18,21 @@ function Footer({ buttonType }) {
 }
 
 const FooterContainer = styled.footer`
-  height: 10%;
   width: 100%;
+  height: 10%;
   text-align: center;
   background-color: gray;
 `;
 
 const FooterButton = styled.button`
+  width: 10vw;
+  height: 5vh;
   margin: 1vmin 1vmin;
   border: none;
   border-radius: 1vmin;
-  width: 10vw;
-  height: 5vh;
+  background-color: #4e6af5;
   color: #ffffff;
-  background-color: blue;
-  font-weight: bold;
-  cursor: pointer;
+  font-weight: 700;
 `;
 
 export default Footer;

--- a/src/components/shared/layout/Footer.js
+++ b/src/components/shared/layout/Footer.js
@@ -1,14 +1,38 @@
 import React from "react";
 import styled from "styled-components";
 
-function Footer() {
-  return <FooterContainer>Footer</FooterContainer>;
+function Footer({ buttonType }) {
+  return (
+    <FooterContainer>
+      {buttonType === "preview" ? (
+        <>
+          <FooterButton>취소</FooterButton>
+          <FooterButton>다운로드</FooterButton>
+        </>
+      ) : (
+        <div>footer</div>
+      )}
+    </FooterContainer>
+  );
 }
 
 const FooterContainer = styled.footer`
   height: 10%;
   width: 100%;
+  text-align: center;
   background-color: gray;
+`;
+
+const FooterButton = styled.button`
+  margin: 1vmin 1vmin;
+  border: none;
+  border-radius: 1vmin;
+  width: 10vw;
+  height: 5vh;
+  color: #ffffff;
+  background-color: blue;
+  font-weight: bold;
+  cursor: pointer;
 `;
 
 export default Footer;

--- a/src/config/constants/pageTypes.js
+++ b/src/config/constants/pageTypes.js
@@ -1,0 +1,5 @@
+const PAGE_TYPES = {
+  PREVIEW: "preview",
+};
+
+export default PAGE_TYPES;


### PR DESCRIPTION
### task card 제목
[레이아웃] 미리보기 
### Task

[- task card 링크
](https://www.notion.so/vanillacoding/0cef546ef9fd4fe0b468635009396bc5)
### Description

- 작업 내용
- 파일 병합 후 다운로드 전 확인을 할수있는 미리보기 페이지 정적버전입니다
- 컴포넌트 재사용을 하여 필요사항들을 구현하였습니다

### Point
![사진](https://user-images.githubusercontent.com/101446818/196113705-60c0f812-6376-49bd-ae01-80fad875c6db.png)

- 미리보기 화면 전체적인 사이즈가 적절하다고 생각하는데 다른분들의 의견을 듣고싶습니다
-  footer 버튼은 useState를 써서 첫 접속시 들어갈 main과 preview페이지를 조건부 렌더링을 하였는데 이부분은 추후 useReducer나 다른 개선 방법을 찾게된다면 개선할 예정입니다 아마 비교 후 병합버튼을 만들때 이부분을 한번 고민해봐야할거같습니다


### ETC
pr이 끝나면 바로 라우팅 작업 들어갈 예정입니다