### PR TITLE
[2022.10.23] Fix: pptx-parser 구조 수정 및 관련 config 수정

### DIFF
--- a/src/config/constants/itemTypes.js
+++ b/src/config/constants/itemTypes.js
@@ -1,6 +1,0 @@
-const ITEM_TYPES = {
-  "p:sp": "text",
-  "p:pic": "image",
-};
-
-export default ITEM_TYPES;

--- a/src/config/pptColors.js
+++ b/src/config/pptColors.js
@@ -1,4 +1,4 @@
-const PRESET_COLORS = {
+const PPT_COLORS = {
   bg1: {
     0: "#fffff",
     95: "#f2f2f2",
@@ -81,4 +81,4 @@ const PRESET_COLORS = {
   },
 };
 
-export default PRESET_COLORS;
+export default PPT_COLORS;

--- a/src/utils/pptxParser.js
+++ b/src/utils/pptxParser.js
@@ -215,7 +215,7 @@ const getSlides = async (pptx) => {
   const slidePaths = await getSlidePaths(pptx);
 
   return Promise.all(
-    slidePaths.map(async (path) => {
+    slidePaths.map(async (path, index) => {
       const slideTextXml = await pptx.file(path).async("text");
       const slide = parser.parseFromString(slideTextXml, "application/xml");
 
@@ -223,6 +223,7 @@ const getSlides = async (pptx) => {
       const items = await getSlideItems(slide, path, pptx);
 
       return {
+        pageNumber: index,
         slideId,
         items,
       };

--- a/src/utils/pptxParser.js
+++ b/src/utils/pptxParser.js
@@ -1,9 +1,12 @@
 import JSZip from "jszip";
 import PRESET_COLORS from "../config/constants/presetColors";
-import ITEM_TYPES from "../config/constants/itemTypes";
 
 const parser = new DOMParser();
 const EMUFactor = 96 / 914400;
+const itemTypes = {
+  "p:sp": "text",
+  "p:pic": "image",
+};
 
 const getSlideSize = async (pptx) => {
   const presentationTextXml = await pptx
@@ -54,15 +57,9 @@ const getSlideId = async (slide) => {
 };
 
 const getItemId = (item) => {
-  const {
-    id: { nodeValue: itemId },
-    name: { nodeValue: itemName },
-  } = item.querySelector("cNvPr").attributes;
+  const itemId = item.querySelector("cNvPr").attributes.name.nodeValue;
 
-  return {
-    itemId,
-    itemName,
-  };
+  return itemId;
 };
 
 const getItemPresetSize = (item) => {
@@ -195,15 +192,15 @@ const getSlideItems = async (slide, slidePath, pptx) => {
 
   return Promise.all(
     items.map(async (item, index) => {
-      const type = ITEM_TYPES[item.tagName] ?? "unidentified item";
-      const id = getItemId(item);
+      const type = itemTypes[item.tagName] ?? "unidentified item";
+      const itemId = getItemId(item);
       const { width, height, x, y } = getItemSize(item);
       const content = await getItemContent(item, type, slidePath, pptx);
 
       return {
         type,
         order: index + 1,
-        id,
+        itemId,
         width,
         height,
         x,


### PR DESCRIPTION
### pptx-parser 구조 수정 및 관련 config 수정

### Description
- 요소의 id를 itemId와 itemName 프로퍼티를 가진 객체를 통해 관리하였는데, itemName으로 단순화하였습니다.
- item 내부에서 id 값이 아닌, itemId로 명칭을 수정하였습니다.
- itemTypes 및 presetColors 파일을 수정하였습니다. 디렉토리 구조 상, 상수화 된 값이라기 보다는 config 값에 가깝다고 생각했습니다.
- slides의 각 slide data의 일부로, pageNumber 항목을 추가하였습니다.
- 이 후 merge 로직에서 pageNumber로 순서를 구분하기 위해서입니다.

### ETC

- 해당 수정 사항 발생으로, pptData 사용 시 itemId 값을 가져올 때 주의 부탁드리겠습다!