### PR TITLE
[2022.10.25] Feat: 미리보기 요청 및 다운로드

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -18,10 +18,13 @@ function Footer() {
   const sequence = useSelector((state) => state.sequence);
   const mergeData = useSelector((state) => state.diffData);
 
-  const { originalPptId, comparablePptId } = useSelector(({ pptData }) => ({
-    originalPptId: pptData[PPT_DATA_TYPES.ORIGINAL_PPT_DATA]?.pptId,
-    comparablePptId: pptData[PPT_DATA_TYPES.COMPARABLE_PPT_DATA]?.pptId,
-  }));
+  const { originalPptId, comparablePptId, mergedPptId, downloadUrl } =
+    useSelector(({ pptData }) => ({
+      originalPptId: pptData[PPT_DATA_TYPES.ORIGINAL_PPT_DATA]?.pptId,
+      comparablePptId: pptData[PPT_DATA_TYPES.COMPARABLE_PPT_DATA]?.pptId,
+      mergedPptId: pptData[PPT_DATA_TYPES.MERGED_PPT_DATA]?.pptId,
+      downloadUrl: pptData[PPT_DATA_TYPES.MERGED_PPT_DATA]?.data?.downloadUrl,
+    }));
 
   const handlePreviousClick = () => {
     dispatch(changePreviousSequence());
@@ -48,7 +51,25 @@ function Footer() {
         pptId: response.data,
       }),
     );
+  };
+
+  const handlePreview = async () => {
+    const response = await axios.get("/api/:ppt_id/preview", {
+      params: { mergedPptId },
+    });
+
+    dispatch(
+      registerData({
+        type: PPT_DATA_TYPES.MERGED_PPT_DATA,
+        pptId: mergedPptId,
+        data: response.data,
+      }),
+    );
     dispatch(changeSequence(SEQUENCES.PREVIEW));
+  };
+
+  const handleDownload = () => {
+    window.location.href = downloadUrl;
   };
 
   switch (sequence) {
@@ -68,14 +89,18 @@ function Footer() {
     case SEQUENCES.COMPARISION:
       return (
         <FooterContainer>
-          <FooterButton onClick={handleMerge}>병합하기</FooterButton>
+          {mergedPptId ? (
+            <FooterButton onClick={handlePreview}>미리보기</FooterButton>
+          ) : (
+            <FooterButton onClick={handleMerge}>병합하기</FooterButton>
+          )}
         </FooterContainer>
       );
     case SEQUENCES.PREVIEW:
       return (
         <FooterContainer>
           <FooterButton>되돌리기</FooterButton>
-          <FooterButton>다운로드</FooterButton>
+          <FooterButton onClick={handleDownload}>다운로드</FooterButton>
         </FooterContainer>
       );
     default:


### PR DESCRIPTION

### task card 제목
[GET] /:ppt_id/preview
### Task

[- task card 링크
](https://www.notion.so/vanillacoding/GET-ppt_id-preview-9293db7834e2443aa5fe2d8162bbb499)
### Description

1. 유저가 병합에 성공하면 미리보기 버튼을 눌러 미리보기 페이지로 이동할 수 있게 하였습니다
2. 유저가 미리보기 페이지에서 다운로드 버튼을 누르면 병합된 다운로드 ppt파일을 받을 수 있게 하였습니다

### Point

요청만 구현한 상태로 미리보기 페이지 view는 로직 수정이 필요합니다.

### ETC
