### PR TITLE
[2022.10.26] Feat: 다운로드 컴포넌트 세팅 및 버그 수정

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     "no-unused-vars": "warn",
     "react/prop-types": "off",
     "react/jsx-props-no-spreading": "off",
+    "react/self-closing-comp": "off",
     "react/jsx-filename-extension": ["warn", { extensions: [".js"] }],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppthub-client",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppthub-client",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.6",
         "@testing-library/jest-dom": "^5.16.5",

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -13,6 +13,7 @@ import NotFoundPage from "../components/NotFoundPage";
 import ErrorPage from "../components/ErrorPage";
 import RightSelectionBar from "../components/RightSelectionBar";
 import SEQUENCES from "../config/constants/sequences";
+import Download from "../components/Download";
 
 function App() {
   const sequence = useSelector((state) => state.sequence);
@@ -24,7 +25,8 @@ function App() {
         <Header />
         <Routes>
           <Route path="/" element={<Main />} />
-          <Route path="/:ppt_id/preview" element={<Preview />} />
+          <Route path="/:id/preview" element={<Preview />} />
+          <Route path="/:id/download" element={<Download />} />
           <Route path="/error" element={<ErrorPage />} />
           <Route path="*" element={<NotFoundPage />} />
         </Routes>

--- a/src/components/Download.js
+++ b/src/components/Download.js
@@ -1,0 +1,49 @@
+import React, { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { useParams } from "react-router-dom";
+
+import styled from "styled-components";
+import axios from "axios";
+
+import PPT_DATA_TYPES from "../config/constants/pptDataTypes";
+import { registerData } from "../features/pptDataReducer";
+import SlideList from "./SlideList";
+
+function Download() {
+  const { id } = useParams();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const getPptData = async () => {
+      const response = await axios.get("/api/:ppt_id/download", {
+        params: { mergedPptId: id },
+      });
+
+      dispatch(
+        registerData({
+          type: PPT_DATA_TYPES.MERGED_PPT_DATA,
+          pptId: id,
+          data: response.data,
+        }),
+      );
+    };
+
+    getPptData();
+  }, [id, dispatch]);
+
+  return (
+    <DownloadContainer>
+      <SlideList fileType={PPT_DATA_TYPES.MERGED_PPT_DATA} />
+    </DownloadContainer>
+  );
+}
+
+const DownloadContainer = styled.div`
+  display: flex;
+  width: 100%;
+  height: 100%;
+  padding: 0 10vw;
+  overflow: auto;
+`;
+
+export default Download;

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { useNavigate } from "react-router-dom";
 
 import styled from "styled-components";
 import axios from "axios";
@@ -17,6 +18,8 @@ function Footer() {
   const dispatch = useDispatch();
   const sequence = useSelector((state) => state.sequence);
   const mergeData = useSelector((state) => state.diffData);
+  const slideOrderList = useSelector((state) => state.slideOrderList);
+  const navigate = useNavigate();
 
   const { originalPptId, comparablePptId, mergedPptId, downloadUrl } =
     useSelector(({ pptData }) => ({
@@ -43,6 +46,7 @@ function Footer() {
       originalPptId,
       comparablePptId,
       mergeData,
+      slideOrderList,
     });
 
     dispatch(
@@ -66,9 +70,13 @@ function Footer() {
       }),
     );
     dispatch(changeSequence(SEQUENCES.PREVIEW));
+    navigate(`/${mergedPptId}/preview`);
   };
 
-  const handleDownload = () => {
+  const handleDownload = async () => {
+    await navigator.clipboard.writeText(
+      `https://ppthub.online/${mergedPptId}/download`,
+    );
     window.location.href = downloadUrl;
   };
 

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -8,7 +8,7 @@ import SlideList from "./SlideList";
 function Preview() {
   return (
     <PreviewContainer>
-      <SlideList viewType={PPT_DATA_TYPES.MERGED_PPT_DATA} />
+      <SlideList fileType={PPT_DATA_TYPES.MERGED_PPT_DATA} />
     </PreviewContainer>
   );
 }

--- a/src/components/SlideList.js
+++ b/src/components/SlideList.js
@@ -9,6 +9,7 @@ function SlideList({ fileType, scrolledListRef, oppositeListRef }) {
   const { slides, slideWidth, slideHeight } = useSelector(
     ({ pptData }) => pptData[fileType].data,
   );
+
   const handleListScroll = (event) => {
     oppositeListRef.current.scrollTop = event.target.scrollTop;
   };

--- a/src/features/pptDataReducer.js
+++ b/src/features/pptDataReducer.js
@@ -42,13 +42,13 @@ const pptDataReducer = createReducer(initialState, {
 
     return state;
   },
-  [initializeDiffData]: (state, action) => {
-    if (Object.keys(action.payload).length === 0) {
-      return initialState;
-    }
+  // [initializeDiffData]: (state, action) => {
+  //   if (Object.keys(action.payload).length === 0) {
+  //     return initialState;
+  //   }
 
-    return state;
-  },
+  //   return state;
+  // },
 });
 
 export default pptDataReducer;

--- a/src/features/slideOrderListReducer.js
+++ b/src/features/slideOrderListReducer.js
@@ -5,25 +5,25 @@ import { registerData } from "./pptDataReducer";
 const slideOrderListReducer = createReducer([], {
   [registerData]: (state, action) => {
     const { type, data } = action.payload;
-    const slideIds = data.slides.map((slide) => slide.slideId);
+    const slideIds = data?.slides.map((slide) => slide.slideId) ?? [];
     const slideIdsSet = new Set(slideIds);
 
     switch (type) {
       case PPT_DATA_TYPES.ORIGINAL_PPT_DATA:
         return Array.from(slideIds);
       case PPT_DATA_TYPES.COMPARABLE_PPT_DATA:
-        return state.reduce((orederedList, cur, index, array) => {
+        return state.reduce((orderedList, slideId, index, array) => {
           if (!slideIdsSet.has(slideId)) {
             return index === array.length - 1
-              ? orederedList.concat([slideId, ...slideIds])
-              : orederedList.concat(slideId);
+              ? orderedList.concat([slideId, ...slideIds])
+              : orderedList.concat(slideId);
           }
 
           const slideIdsIndex = slideIds.indexOf(slideId);
 
           return index === array.length - 1
-            ? orederedList.concat(slideIds)
-            : orederedList.concat(slideIds.splice(0, slideIdsIndex + 1));
+            ? orderedList.concat(slideIds)
+            : orderedList.concat(slideIds.splice(0, slideIdsIndex + 1));
         }, []);
       default:
         return state;


### PR DESCRIPTION
### task card 제목

### Task

- task card 링크

### Description

1. 유저가 다운로드 링크로 들어오면 다운로드 페이지로 이동할 수 있게 라우터와 컴포넌트를 설정했습니다.
2. 린트 룰을 추가했습니다.
3. 리덕스 에러를 추가 처리했습니다

### Point

다운로드 페이지에서 서버로 데이터를 받아와 리덕스에 저장은 되는데 슬라이드 랜더링에서 오류가 있습니다. 슬라이드 리스트 컴포넌트에서 리덕스에서 데이터를 받지 못하고 있는데 이부분은 코드확인 후 에러 처리가 필요해보입니다.

### ETC
